### PR TITLE
Data-model/storage: Portability and Extensibility

### DIFF
--- a/data/backend/backend.go
+++ b/data/backend/backend.go
@@ -1,0 +1,20 @@
+package backend
+
+import (
+	"github.com/coralproject/pillar/data"
+)
+
+// Backend defines methods necessary for data storage and retrieval.
+//
+// Notably, methods that perform function such as index creation have been
+// ommitted; the thinking being that index creation should be internal to the
+// Backend implementation (if it's necessary at all).
+type Backend interface {
+	Comment(string) (*data.Comment, error)
+	SetComment(*data.Comment) error
+	DeleteComment(string) error
+
+	// Close should terminate any open connections and perform any necessary
+	// cleanup.
+	Close() error
+}

--- a/data/backend/backend_test.go
+++ b/data/backend/backend_test.go
@@ -1,0 +1,48 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/coralproject/pillar/data"
+	"github.com/coralproject/pillar/data/backend/mongodb"
+)
+
+// testBackend is a method for testing Backend interfaces.
+func testBackend(b Backend, t *testing.T) {
+
+	testComment := &data.Comment{
+		ID: "1234",
+	}
+
+	if err := b.SetComment(testComment); err != nil {
+		t.Error(err)
+	}
+
+	retrievedComment, err := b.Comment(testComment.ID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if retrievedComment.ID != testComment.ID {
+		t.Errorf("Retrieved comment ID, %s, did not match the test comment ID, %s", retrievedComment.ID, testComment.ID)
+	}
+
+	if err := b.DeleteComment(testComment.ID); err != nil {
+		t.Error(err)
+	}
+
+	if err := b.Close(); err != nil {
+		t.Error(err)
+	}
+
+}
+
+func TestMongoDBBackend(t *testing.T) {
+	b, err := mongodb.NewMongoDBBackend("mongodb://localhost:27017", "pillar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the generic backend test.
+	testBackend(b, t)
+}

--- a/data/backend/mongodb/mongodb.go
+++ b/data/backend/mongodb/mongodb.go
@@ -1,0 +1,88 @@
+package mongodb
+
+import (
+	"github.com/coralproject/pillar/data"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+const (
+	commentsCollection string = "comments"
+)
+
+var (
+	indicies = []mgo.Index{
+		mgo.Index{
+			Key:      []string{"id"},
+			Unique:   true,
+			DropDups: true,
+		},
+	}
+)
+
+// MongoDBBackend represents a MongoDB backend.
+type MongoDBBackend struct {
+	database string
+	session  *mgo.Session
+}
+
+// NewMongoDBBackend creates a new MongoDBBackendBackend object using a
+// MongoDB conection string. Any database defined in the connection string
+// will be overridden by the argument-specified database.
+func NewMongoDBBackend(url, database string) (*MongoDBBackend, error) {
+	session, err := mgo.Dial(url)
+	if err != nil {
+		return nil, err
+	}
+
+	m := &MongoDBBackend{
+		database: database,
+		session:  session,
+	}
+
+	// Ensure indicies are built.
+	for _, index := range indicies {
+		if err := m.comments().EnsureIndex(index); err != nil {
+			return nil, err
+		}
+	}
+
+	return m, nil
+}
+
+// comments is shorthand for the comments collection object.
+func (m *MongoDBBackend) comments() *mgo.Collection {
+	return m.session.DB(m.database).C(commentsCollection)
+}
+
+// Comment returns the comment with the specified ID if it exists.
+func (m *MongoDBBackend) Comment(id string) (*data.Comment, error) {
+	comment := &data.Comment{}
+	if err := m.comments().Find(bson.M{"id": id}).One(comment); err != nil {
+		return nil, err
+	}
+	return comment, nil
+}
+
+// SetComment creates or updates a comment with the ID of the specified
+// comment object.
+func (m *MongoDBBackend) SetComment(comment *data.Comment) error {
+	if _, err := m.comments().Upsert(bson.M{"id": comment.ID}, comment); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteComment removes a comment with the specified ID.
+func (m *MongoDBBackend) DeleteComment(id string) error {
+	if err := m.comments().Remove(bson.M{"id": id}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close closes the underlying session.
+func (m *MongoDBBackend) Close() error {
+	m.session.Close()
+	return nil
+}

--- a/data/comment.go
+++ b/data/comment.go
@@ -1,0 +1,6 @@
+package data
+
+// Comment is a comment in any system.
+type Comment struct {
+	ID string `json:"id" bson:"id"`
+}

--- a/data/comment_test.go
+++ b/data/comment_test.go
@@ -1,0 +1,9 @@
+package data
+
+import (
+	"testing"
+)
+
+func TestComment(t *testing.T) {
+	// noop.
+}


### PR DESCRIPTION
Hey all!

This is the beginning of a proposal intended to address two main issues in the current architecture.

* **Portability** of the data-model.
* **Extensibility** of the data-storage.

It is by no means complete, but I've structured it as an out-of-band code update that can be merged (if that makes sense) without impacting the existing application. That is, everything is housed under the previously non-existent directory, `data`.

As it stands now (and as I understand it) the entirety of the Go data model within pillar exists as part of the [crud package](https://github.com/coralproject/pillar/tree/master/pkg/crud). Within this package there is a very close relationship between the driver of the current backend, MongoDB, and the structure of the Go objects meant to represent the data stored there. Examples would be the prevalence of [BSON](http://bsonspec.org/) data-types such as `bson.ObjectId` and `bson.M`.

The argument I'd like to make is that although the use of these objects does seemingly facilitate the coding of pillar, it introduces structural issues that complicate the use of pillar code outside of this application and interfere with the ability of other developers to expand on the work here.

From the point of view of the data-model, adopting the structures of the storage-backend introduces idiosyncrasies that may not be intentional. For example, `bson.ObjectId` requires that a 12-byte identifier be used to track a given entry, something that may not be valuable during a comment import from a system that uses string identifiers such as "orgainization.section.author.id". In that hypothetical scenario, an entry will need to be manipulated to meet the storage-backend's requirements even if the application that is presently using the data-model has no reason to know (or more importantly, care) that MongoDB exists as part of the pipeline it's interacting with.

The first step here is to sever that relationship and establish a "clean" package, `data`, that contains the useful structure and logic of the pillar data-types without the dependency on knowing the data's eventual use or physical destination.

Once this work is done, it's easier to describe a storage backend in the same terms as the data-model. The second step is to write a backend definition as a [Go interface](https://golang.org/doc/effective_go.html#interfaces), an interface that defines storage and retrieval as interactions with backend-agnostic objects. Because multiple types can satisfy an interface, we now have a working *specification* of what a `Backend` needs to do. Writing a MongoDB implementation of the `Backend` interface is straight forward and allows us to contain the specific logic it requires to a single package by not exporting it. Another advantage of this pattern is **testing**. Data-storage backends can now be tested for compliance with the single, universal `Backend` definition.

This pull request contains a start on implementation of what I've written about here.



