### PR TITLE
Supporting CORS pre-flight on tags.

### DIFF
--- a/app/pillar/handler/tag.go
+++ b/app/pillar/handler/tag.go
@@ -6,12 +6,22 @@ import (
 	"net/http"
 )
 
+func TagsPreflight(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+  w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE")
+  w.Header().Set("Access-Control-Allow-Headers",
+      "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-CoralCustom")
+	doRespond(w, nil, nil)
+}
+
+
 func GetTags(w http.ResponseWriter, r *http.Request) {
 	jsonObject := crud.Tag{}
 	json.NewDecoder(r.Body).Decode(&jsonObject)
 
 	// Write content-type, status code and payload
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	dbObject, err := crud.GetTags()
 	doRespond(w, dbObject, err)
 }
@@ -23,6 +33,7 @@ func UpsertTag(w http.ResponseWriter, r *http.Request) {
 
 	// Write content-type, status code and payload
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	dbObject, err := crud.UpsertTag(&jsonObject)
 	doRespond(w, dbObject, err)
 }
@@ -34,6 +45,7 @@ func DeleteTag(w http.ResponseWriter, r *http.Request) {
 
 	// Write content-type, status code and payload
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	err := crud.DeleteTag(&jsonObject)
 	doRespond(w, nil, err)
 }

--- a/app/pillar/main.go
+++ b/app/pillar/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/coralproject/pillar/app/pillar/route"
-	"github.com/gorilla/handlers"
 	"log"
 	"net/http"
 )
@@ -11,5 +10,5 @@ func main() {
 
 	router := route.NewRouter()
 
-	log.Printf(http.ListenAndServe(":8080", handlers.CORS()(router)).Error())
+	log.Printf(http.ListenAndServe(":8080", router).Error())
 }

--- a/app/pillar/route/routes.go
+++ b/app/pillar/route/routes.go
@@ -30,4 +30,8 @@ var routes = []Route{
 	Route{"GET",    "/api/tags", handler.GetTags},
 	Route{"POST",   "/api/tag", handler.UpsertTag},
 	Route{"DELETE", "/api/tag", handler.DeleteTag},
+	
+	Route{"OPTIONS",  "/api/tag", handler.TagsPreflight},
+	Route{"OPTIONS",  "/api/tags", handler.TagsPreflight},
+
 }


### PR DESCRIPTION
No need to merge this PR, I just wanted to show you the hack I had to do to get it working with Cay.

We are using fetch() on the front-end, which uses CORS and sends a pre-flight OPTIONS request to ask for available methods on the API side. 

Looks like the default setup of the Gorilla handlers CORS middleware do not handle CORS requests as I expected, maybe tweaking the initialization options would do the trick.

I had to manually set the OPTIONS pre-flight response and CORS headers on each of the tags API entries, but I assume there should be a more generic way of doing this, maybe wrapping the router on creation.

Adding an issue on this.