### PR TITLE
Add indices to user_statistics for sorting

### DIFF
--- a/pkg/model/index.go
+++ b/pkg/model/index.go
@@ -37,6 +37,89 @@ var Indicies = []Index{
 		},
 	},
 
+	// User Statistics indexes
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.all.count"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.all.replied_count"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.all.replied_ratio"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.all.reply_count"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.all.reply_ratio"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.all.word_count_average"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.ModeratorDeleted.count"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.ratios.ModeratorDeleted"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.ModeratorApproved.count"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.ratios.ModeratorApproved"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.CommunityFlagged.count"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.comments.all.ratios.Communityflagged"},
+		},
+	},
+
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.actions.received.likes.count"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.actions.performed.likes.count"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.actions.received.flags.count"},
+		},
+	},
+	{
+		UserStatistics, mgo.Index{
+			Key: []string{"statistics.actions.performed.flags.count"},
+		},
+	},
+
 	//Comments Indexes
 	{
 		Comments, mgo.Index{

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -29,6 +29,7 @@ const (
 
 	//Various Collections
 	Users          string = "users"
+	UserStatistics string = "user_statistics"
 	Assets         string = "assets"
 	Actions        string = "actions"
 	Comments       string = "comments"


### PR DESCRIPTION
## What does this PR do?

Adds indexes to support sorting / filtering.  #128 

## How do I test this PR?

Run pillar, indexes are automatically created, verify they are in the mongo client, look for table scans during filtering operations.

@coralproject/backend

