### PR TITLE
close calculation session

### DIFF
--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -95,6 +95,8 @@ func Calculate() {
 		log.Fatal(uid, "main", "Failed on connecting with MongoDB. Error: %v", err)
 	}
 
+	defer b.Close()
+
 	log.User(uid, "main", "Calculating stats")
 	ctx := backend.NewBackendContext(context.Background(), backend.NewIdentityMap(b))
 	if err := CalculateUserStatistics(ctx); err != nil {


### PR DESCRIPTION
## What does this PR do?

Closes the session used in calculating stats. Fix for #127

## How do I test this PR?

- leave pillar running with stats/ingestion for 24+ hrs
- check for "http: Accept error: accept tcp [::]:8080: accept4: too many open files" error in logs. Should be a continuous stream of them.

@coralproject/backend

