### PR TITLE
auto-ack off

### DIFF
--- a/pkg/amqp/amqp.go
+++ b/pkg/amqp/amqp.go
@@ -109,7 +109,7 @@ func (m *MQ) Receive() (<-chan amqp.Delivery, error) {
 	return m.Channel.Consume(
 		q.Name, // queue
 		"",     // consumer
-		true,   // auto-ack
+		false,  // auto-ack
 		false,  // exclusive
 		false,  // no-local
 		false,  // no-wait


### PR DESCRIPTION
## What does this PR do?
Turns off auto ack. The library we're using has a memory problem caused by auto ack. 

https://github.com/streadway/amqp/issues/149

## How do I test this PR?

publish events to rabbitmq from pillar and consume them in another service using pillar's amqp.go.  You should see publishes, delivers, and acks. You shouldn't see any no "Deliver (noack)" in the rabbitmq admin console (http://localhost:15672/ if you're running it locally). 

@coralproject/backend

