### PR TITLE
refactors, errors, logs and fix remove from empty bug

### DIFF
--- a/pkg/service/search_cron.go
+++ b/pkg/service/search_cron.go
@@ -77,6 +77,7 @@ func addTag(c *web.AppContext, id bson.ObjectId, tag string) *model.User {
 	}
 
 	//add the new tag
+	log.Printf("Adding tag [%s] to user [%s]", tag, user.ID)
 	tags := append(user.Tags, tag)
 	c.MDB.DB.C(model.Users).UpdateId(id, bson.M{"$set": bson.M{"tags": tags}})
 	c.SD.Client.Inc("New_Tag_Added", 1, 1.0)
@@ -98,6 +99,7 @@ func removeTag(c *web.AppContext, id bson.ObjectId, tag string) *model.User {
 		tags = append(tags, one)
 	}
 
+	log.Printf("Removing tag [%s] from user [%s]", tag, user.ID)
 	c.MDB.DB.C(model.Users).UpdateId(id, bson.M{"$set": bson.M{"tags": tags}})
 	c.SD.Client.Inc("Tag_Removed", 1, 1.0)
 	return &user

--- a/pkg/service/search_cron.go
+++ b/pkg/service/search_cron.go
@@ -29,11 +29,14 @@ func UpdateSearch() {
 }
 
 func doUpdateSearch(c *web.AppContext, search model.Search) {
+
+	log.Printf("Starting UpdateSearch: %s", search.Name)
 	//map of new users from search
-	m, a := getNewUsers(c.MDB, search)
-	if m == nil || len(m) == 0 {
-		log.Printf("UpdateSearch - no new users, skipping [%s]\n", search.Query)
+	m, a, err := getNewUsers(c.MDB, search)
+	if err != nil {
+		log.Printf("UpdateSearch failed: %s", search.Name)
 		return
+
 	}
 
 	//remove tag when user from old list are no longer in new list
@@ -46,6 +49,7 @@ func doUpdateSearch(c *web.AppContext, search model.Search) {
 		}
 	}
 
+	// add tags to users who are returned by the search
 	for _, value := range m {
 		if user := addTag(c, value.ID, search.Tag); user != nil {
 			p := model.Event{model.EventTagAdded, model.PayloadTag{search.Tag, *user}}
@@ -100,15 +104,16 @@ func removeTag(c *web.AppContext, id bson.ObjectId, tag string) *model.User {
 }
 
 //returns new sets of users from the search
-func getNewUsers(db *db.MongoDB, search model.Search) (map[bson.ObjectId]model.User, []model.User) {
+func getNewUsers(db *db.MongoDB, search model.Search) (map[bson.ObjectId]model.User, []model.User, error) {
 
-	ids := getUserIds(search)
-	if ids == nil || len(ids) == 0 {
-		return nil, nil
+	ids, err := getUserIds(search)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	m := make(map[bson.ObjectId]model.User, len(ids))
 	a := make([]model.User, len(ids))
+
 	for i := 0; i < len(ids); i++ {
 		var user model.User
 		key := bson.ObjectIdHex(ids[i])
@@ -117,5 +122,5 @@ func getNewUsers(db *db.MongoDB, search model.Search) (map[bson.ObjectId]model.U
 		a[i] = user
 	}
 
-	return m, a
+	return m, a, nil
 }


### PR DESCRIPTION
## What does this PR do?

- Fixes #138 and #180, #185
- Introduces error handling into the relevant parts of the Search package
- Refactors incorrect [] usage (caused the panics for empty ids)
- Rethink and overhaul logging for clarity

## How do I test this PR?

See instructions in issue #138 
Watch logs, no more panics should occur.
Users should be removed from searches that become empty as expected.

Also, you can play with the env var to control the max search size.

@coralproject/backend

